### PR TITLE
Proxy should also handle container subdomains 

### DIFF
--- a/dork_compose/auxiliary/proxy/dockergen/nginx.tmpl
+++ b/dork_compose/auxiliary/proxy/dockergen/nginx.tmpl
@@ -134,7 +134,7 @@ upstream {{ $host }} {
 
 {{ if eq $https_method "redirect" }}
 server {
-	server_name {{ $host }};
+	server_name .{{ $host }};
 	listen 80 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
@@ -142,7 +142,7 @@ server {
 {{ end }}
 
 server {
-	server_name {{ $host }};
+	server_name .{{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
@@ -189,7 +189,7 @@ server {
 {{ if or (not $is_https) (eq $https_method "noredirect") }}
 
 server {
-	server_name {{ $host }};
+	server_name .{{ $host }};
 	listen 80 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
@@ -215,7 +215,7 @@ server {
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
-	server_name {{ $host }};
+	server_name .{{ $host }};
 	listen 443 ssl http2 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 500;


### PR DESCRIPTION
Currently, subdomain.project.dork.io maps to localhost in DNS, but the nginx proxy doesn't pass the request along. Added some dots to the nginx template so we can use subdomains. NGINX prioritizes exact hostnames over wildcard hostnames, so a user can still explicitly use a subdomain for a different container if they like.